### PR TITLE
Feat: #39 Add RoleManagementPage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import AdminPage from 'Pages/AdminPage';
 import Parent from 'Pages/Parent';
 import Teacher from 'Pages/Teacher';
 import Help from 'Pages/Help';
+import RoleManagement from 'Pages/RoleManagementPage';
 
 function App() {
   return (
@@ -22,6 +23,7 @@ function App() {
         <Route path={ROUTES.SIGN_IN} component={LoginPage} />
         <Route path={ROUTES.SIGN_UP} component={SignUpPage} />
         <Route path={ROUTES.ADMIN} component={AdminPage} />
+        <Route path={ROUTES.ROLE_MANAGEMENT} component={RoleManagement} />
       </Switch>
     </Router>
   );

--- a/src/Pages/AdminPage/AdminPage.js
+++ b/src/Pages/AdminPage/AdminPage.js
@@ -3,6 +3,7 @@ import searchIcon from 'Assets/search.png';
 import { style } from './AdminPageStyle';
 import { AiOutlineRight, AiOutlineLeft } from 'react-icons/ai';
 import userData from 'utils/userData.json';
+import { useHistory } from 'react-router-dom';
 
 const properties = [
   { label: 'Parents', value: 'Parents' },
@@ -10,6 +11,7 @@ const properties = [
 ];
 
 function AdminPage() {
+  const history = useHistory();
   const [datas, setDatas] = useState([]);
   const [, setSearchValue] = useState('');
   const [checkedArray, setCheckedArray] = useState([]);
@@ -28,6 +30,10 @@ function AdminPage() {
     setCheckedArray(newChecked);
   };
 
+  const goRoleManagementPage = () => {
+    history.push('/role-management');
+  };
+
   useEffect(() => {
     setDatas(userData);
   }, []);
@@ -36,7 +42,7 @@ function AdminPage() {
     <div>
       <TableContainer>
         <TableTitleContainer>
-          <TableTitle>User List</TableTitle>
+          <TableTitle>사용자 목록</TableTitle>
           <SearchContainer>
             <SearchIcon src={searchIcon} alt="search-icon" />
             <Searchbox
@@ -44,6 +50,9 @@ function AdminPage() {
               placeholder="Search Name"
               onChange={onHandleSearch}
             />
+            <GoRolePageButton onClick={goRoleManagementPage}>
+              권한 별 사용자 목록 보기
+            </GoRolePageButton>
           </SearchContainer>
         </TableTitleContainer>
         <table>
@@ -100,4 +109,5 @@ const {
   TableFooter,
   TableTitle,
   TableTitleContainer,
+  GoRolePageButton,
 } = style;

--- a/src/Pages/AdminPage/AdminPageStyle.js
+++ b/src/Pages/AdminPage/AdminPageStyle.js
@@ -58,8 +58,8 @@ export const TableTitleContainer = styled.div`
 `;
 
 export const TableTitle = styled.h4`
-  font-size: 1.25rem;
-  font-weight: 500;
+  font-size: 24px;
+  font-weight: 600;
   line-height: 1.6rem;
   letter-spacing: 0.0075em;
   padding-top: 0.5rem;
@@ -85,7 +85,7 @@ export const Searchbox = styled.input`
   &:hover {
     width: 240px;
     color: #1a2634;
-    background-color: #f0f0f0;
+    background-color: #f6ffed;
   }
 `;
 
@@ -120,6 +120,25 @@ export const RoleButonWrapper = styled.div`
   text-align: right;
 `;
 
+export const GoRolePageButton = styled.button`
+  display: flex;
+  -webkit-box-align: center;
+  align-items: center;
+  padding: 5px 10px;
+  border-radius: 5px;
+  font-size: 17px;
+  font-weight: 600;
+  color: rgb(44, 44, 49);
+
+  &:hover {
+    background-color: #f6ffed;
+  }
+
+  & > svg {
+    margin-right: 0.7rem;
+  }
+`;
+
 export const style = {
   Cell,
   CheckButton,
@@ -130,4 +149,5 @@ export const style = {
   TableFooter,
   TableTitle,
   TableTitleContainer,
+  GoRolePageButton,
 };

--- a/src/Pages/AdminPage/AdminPageStyle.js
+++ b/src/Pages/AdminPage/AdminPageStyle.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 export const TableContainer = styled.div`
   max-width: 960px;
   margin: 3rem auto;
-  // background-color: #f5f5f5;
 
   & > table {
     width: 100%;
@@ -114,6 +113,11 @@ export const TableFooter = styled.div`
     cursor: pointer;
     margin-left: 3rem;
   }
+`;
+
+export const RoleButonWrapper = styled.div`
+  width: 100%;
+  text-align: right;
 `;
 
 export const style = {

--- a/src/Pages/RoleManagementPage/RoleManagementPage.js
+++ b/src/Pages/RoleManagementPage/RoleManagementPage.js
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import testData from 'utils/testData.json';
+import { style } from './RoleManagementPageStyle';
+
+const properties = [
+  { label: '부모님만 이용 가능 페이지', value: '부모님만 이용 가능 페이지' },
+  { label: '자란다 선생님 보기', value: '자란다 선생님 보기' },
+];
+
+function RoleManagementPage() {
+  const [filteredData, setFilteredData] = useState([...testData]);
+  const [role, setRole] = useState('');
+
+  const onSelectChange = (e) => {
+    setRole(e.target.value);
+    const matchValue = testData.filter((data) =>
+      data.role.includes(e.target.value),
+    );
+    setFilteredData(matchValue);
+  };
+
+  // role에 따른 역할 설정은 localStorage에
+  // 실제 값이 들어온 다음에 진행 예정
+
+  //   const onSubmitRoleManagement = () => {
+  //     if(role === '선생님')
+  //     else if(role === '부모님')
+  //     else (role === '학생')
+  //   };
+
+  return (
+    <div>
+      <TableContainer>
+        <TableHeader>
+          <TableTitle>역할 별 전체 권한 설정</TableTitle>
+          <SelectContainer>
+            <SelectBox onChange={onSelectChange}>
+              <option value="">역할 설정</option>
+              <option value="선생님">선생님</option>
+              <option value="부모님">부모님</option>
+              <option value="학생">학생</option>
+            </SelectBox>
+          </SelectContainer>
+        </TableHeader>
+        <table>
+          <thead>
+            <tr>
+              <Cell>Role</Cell>
+              <Cell>Page Authentication</Cell>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredData.map(
+              (data, index) =>
+                data.role !== 'admin' && (
+                  <tr key={index}>
+                    <Cell>{data.role}</Cell>
+                    <Cell>
+                      <div key={index}>
+                        {properties.map((property, index) => (
+                          <RoleButton key={index}>{property.label}</RoleButton>
+                        ))}
+                      </div>
+                    </Cell>
+                  </tr>
+                ),
+            )}
+          </tbody>
+        </table>
+        <TableFooter>
+          <div>
+            <RoleButton
+            // onClick={onSubmitRoleManagement}
+            >
+              {role} 페이지 권한 확정
+            </RoleButton>
+          </div>
+        </TableFooter>
+      </TableContainer>
+    </div>
+  );
+}
+
+export default RoleManagementPage;
+
+const {
+  TableHeader,
+  RoleButton,
+  SelectBox,
+  TableFooter,
+  Cell,
+  SelectContainer,
+  TableContainer,
+  TableTitle,
+} = style;

--- a/src/Pages/RoleManagementPage/RoleManagementPage.js
+++ b/src/Pages/RoleManagementPage/RoleManagementPage.js
@@ -3,6 +3,7 @@ import testData from 'utils/testData.json';
 import { style } from './RoleManagementPageStyle';
 import { FaRegUser } from 'react-icons/fa';
 import { useHistory } from 'react-router-dom';
+import { LOCAL_STORAGE } from 'utils/constants';
 
 const properties = [
   { label: '부모님만 이용 가능 페이지', value: '부모님만 이용 가능 페이지' },
@@ -26,14 +27,13 @@ function RoleManagementPage() {
     history.push('/admin');
   };
 
-  // role에 따른 역할 설정은 localStorage에
-  // 실제 값이 들어온 다음에 진행 예정
-
-  //   const onSubmitRoleManagement = () => {
-  //     if(role === '선생님')
-  //     else if(role === '부모님')
-  //     else (role === '학생')
-  //   };
+  const onSubmitRoleManagement = () => {
+    if (role === '선생님')
+      LOCAL_STORAGE.set('role', '[해당 역할에 맞는 pages]');
+    else if (role === '부모님')
+      LOCAL_STORAGE.set('role', '[해당 역할에 맞는 pages]');
+    else LOCAL_STORAGE.set('role', '[해당 역할에 맞는 pages]');
+  };
 
   return (
     <div>
@@ -80,9 +80,7 @@ function RoleManagementPage() {
         </table>
         <TableFooter>
           <div>
-            <SubmitButton
-            // onClick={onSubmitRoleManagement}
-            >
+            <SubmitButton onClick={onSubmitRoleManagement}>
               페이지 권한 확정
             </SubmitButton>
           </div>

--- a/src/Pages/RoleManagementPage/RoleManagementPage.js
+++ b/src/Pages/RoleManagementPage/RoleManagementPage.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import testData from 'utils/testData.json';
 import { style } from './RoleManagementPageStyle';
+import { FaRegUser } from 'react-icons/fa';
+import { useHistory } from 'react-router-dom';
 
 const properties = [
   { label: '부모님만 이용 가능 페이지', value: '부모님만 이용 가능 페이지' },
@@ -8,6 +10,7 @@ const properties = [
 ];
 
 function RoleManagementPage() {
+  const history = useHistory();
   const [filteredData, setFilteredData] = useState([...testData]);
   const [role, setRole] = useState('');
 
@@ -17,6 +20,10 @@ function RoleManagementPage() {
       data.role.includes(e.target.value),
     );
     setFilteredData(matchValue);
+  };
+
+  const goAdminPage = () => {
+    history.push('/admin');
   };
 
   // role에 따른 역할 설정은 localStorage에
@@ -40,6 +47,10 @@ function RoleManagementPage() {
               <option value="부모님">부모님</option>
               <option value="학생">학생</option>
             </SelectBox>
+            <GoAdminPageButton onClick={goAdminPage}>
+              <FaRegUser />
+              전체 사용자 목록 보기
+            </GoAdminPageButton>
           </SelectContainer>
         </TableHeader>
         <table>
@@ -69,11 +80,11 @@ function RoleManagementPage() {
         </table>
         <TableFooter>
           <div>
-            <RoleButton
+            <SubmitButton
             // onClick={onSubmitRoleManagement}
             >
-              {role} 페이지 권한 확정
-            </RoleButton>
+              페이지 권한 확정
+            </SubmitButton>
           </div>
         </TableFooter>
       </TableContainer>
@@ -92,4 +103,6 @@ const {
   SelectContainer,
   TableContainer,
   TableTitle,
+  SubmitButton,
+  GoAdminPageButton,
 } = style;

--- a/src/Pages/RoleManagementPage/RoleManagementPageStyle.js
+++ b/src/Pages/RoleManagementPage/RoleManagementPageStyle.js
@@ -1,0 +1,101 @@
+import styled from 'styled-components';
+
+export const TableContainer = styled.div`
+  max-width: 960px;
+  margin: 3rem auto;
+
+  & > table {
+    width: 100%;
+    vertical-align: middle;
+  }
+
+  & > table > thead > tr > th {
+    font-weight: 500;
+  }
+`;
+
+export const TableHeader = styled.div`
+  padding-left: 16px;
+  padding-right: 8px;
+  min-height: 64px;
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const TableTitle = styled.h4`
+  font-size: 1.25rem;
+  font-weight: 500;
+  line-height: 1.6rem;
+  letter-spacing: 0.0075em;
+  padding-top: 0.5rem;
+`;
+
+export const Cell = styled.th`
+  display: table-cell;
+  padding: 16px;
+  font-size: 0.875rem;
+  text-align: left;
+  font-weight: 400;
+  line-height: 1.5rem;
+  border-bottom: 1px solid rgba(224, 224, 224, 1);
+  letter-spacing: 0.01071em;
+  vertical-align: inherit;
+
+  & > div {
+    display: flex;
+  }
+`;
+
+export const RoleButton = styled.button`
+  display: flex;
+  -webkit-box-align: center;
+  padding-top: 10px;
+  align-items: center;
+  margin-right: 10px;
+  padding: 10px 20px;
+  background-color: gray;
+  color: white;
+  border-radius: 50px;
+  border: 1px solid rgb(233, 235, 237);
+  color: white;
+`;
+
+export const SelectBox = styled.select`
+  border: none;
+  font-size: 19px;
+  font-weight: 500;
+  padding: 10px;
+  color: rgb(70, 70, 77);
+`;
+
+export const TableFooter = styled.div`
+  min-height: 52px;
+  padding-right: 2px;
+  text-align: right;
+
+  & > div {
+    padding-top: 20px;
+    font-size: 20px;
+    margin-right: 1rem;
+    float: right;
+  }
+
+  & > div > button {
+    cursor: pointer;
+  }
+`;
+
+export const SelectContainer = styled.div`
+  display: flex;
+`;
+
+export const style = {
+  TableHeader,
+  RoleButton,
+  SelectBox,
+  TableFooter,
+  Cell,
+  SelectContainer,
+  TableContainer,
+  TableTitle,
+};

--- a/src/Pages/RoleManagementPage/RoleManagementPageStyle.js
+++ b/src/Pages/RoleManagementPage/RoleManagementPageStyle.js
@@ -23,8 +23,8 @@ export const TableHeader = styled.div`
 `;
 
 export const TableTitle = styled.h4`
-  font-size: 1.25rem;
-  font-weight: 500;
+  font-size: 24px;
+  font-weight: 600;
   line-height: 1.6rem;
   letter-spacing: 0.0075em;
   padding-top: 0.5rem;
@@ -66,6 +66,7 @@ export const SelectBox = styled.select`
   font-weight: 500;
   padding: 10px;
   color: rgb(70, 70, 77);
+  margin-right: 1rem;
 `;
 
 export const TableFooter = styled.div`
@@ -85,6 +86,41 @@ export const TableFooter = styled.div`
   }
 `;
 
+export const SubmitButton = styled.button`
+  display: flex;
+  -webkit-box-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  align-items: center;
+  width: 200px;
+  height: 50px;
+  border-radius: 5px;
+  background-color: #52c41a;
+  color: white;
+  font-size: 18px;
+  font-weight: 500;
+`;
+
+export const GoAdminPageButton = styled.button`
+  display: flex;
+  -webkit-box-align: center;
+  align-items: center;
+  padding: 5px 10px;
+  border-radius: 5px;
+  font-size: 17px;
+  font-weight: 600;
+  color: rgb(44, 44, 49);
+
+  &:hover {
+    background-color: #f6ffed;
+    cursor: pointer;
+  }
+
+  & > svg {
+    margin-right: 0.7rem;
+  }
+`;
+
 export const SelectContainer = styled.div`
   display: flex;
 `;
@@ -98,4 +134,6 @@ export const style = {
   SelectContainer,
   TableContainer,
   TableTitle,
+  SubmitButton,
+  GoAdminPageButton,
 };

--- a/src/Pages/RoleManagementPage/index.js
+++ b/src/Pages/RoleManagementPage/index.js
@@ -1,0 +1,3 @@
+import RoleManagement from './RoleManagementPage';
+
+export default RoleManagement;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -21,6 +21,7 @@ export const ROUTES = {
   SIGN_IN: '/signin',
   SIGN_UP: '/signup',
   ADMIN: '/admin',
+  ROLE_MANAGEMENT: '/role-management',
 };
 
 export const ROLES = {

--- a/src/utils/testData.json
+++ b/src/utils/testData.json
@@ -1,0 +1,62 @@
+[
+  {
+    "userId": "park",
+    "password": "",
+    "name": "박채연",
+    "age": 0,
+    "creditCard": {
+      "cardNumber": "0000-0000-0000-0000",
+      "name": "",
+      "expired": "0624",
+      "CVC": "000"
+    },
+    "role": "부모님",
+    "address": "",
+    "menubar": ["aaa", "bbbb", "cccc"]
+  },
+  {
+    "userId": "jung",
+    "password": "",
+    "name": "정유정",
+    "age": 0,
+    "creditCard": {
+      "cardNumber": "0000-0000-0000-0000",
+      "name": "",
+      "expired": "0624",
+      "CVC": "000"
+    },
+    "role": "학생",
+    "address": "",
+    "menubar": ["dddddd", "eee", "ff", "g", "h"]
+  },
+  {
+    "userId": "lee",
+    "password": "",
+    "name": "이주영",
+    "age": 0,
+    "creditCard": {
+      "cardNumber": "0000-0000-0000-0000",
+      "name": "",
+      "expired": "0624",
+      "CVC": "000"
+    },
+    "role": "선생님",
+    "address": "",
+    "menubar": ["aaa", "bbbb", "cccc"]
+  },
+  {
+    "userId": "kim",
+    "password": "",
+    "name": "김이수",
+    "age": 0,
+    "creditCard": {
+      "cardNumber": "0000-0000-0000-0000",
+      "name": "",
+      "expired": "0624",
+      "CVC": "000"
+    },
+    "role": "부모님",
+    "address": "",
+    "menubar": ["dddddd", "eee", "ff", "g", "h"]
+  }
+]


### PR DESCRIPTION
### 작업 상세
역할 별 이용 가능한 페이지를 한꺼번에 설정해주는 RoleManagementPage에 해당하는 UI, 기능을 추가하였습니다.
자세한 부분은 #39 issue를 확인 해주시면 됩니다.

### 주의 요망
- line5의 `properties` 변수는 단순 예시입니다.
- line2에 `import`된 `testData`는 단순 예시입니다.
- line22~29 의 주석에 해당하는 함수는 localStorage에 실제 user 정보가 들어온 뒤 추가적으로 작업 진행하겠습니다.
- UI는 추가적으로 피드백을 받으면서 개선하겠습니다.

수정사항, 문제 있다면 말씀 주시면 감사하겠습니다!